### PR TITLE
fix: change simple-git-hooks from postinstall to prepare

### DIFF
--- a/full-react-css-modules/package.json
+++ b/full-react-css-modules/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "bunup",
     "dev": "bun run --cwd test/ui dev",
-    "postinstall": "bun simple-git-hooks",
+    "prepare": "bun simple-git-hooks",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "release": "bumpp --commit --push --tag",

--- a/full-react-pure-css/package.json
+++ b/full-react-pure-css/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "bunup",
     "dev": "bun run --cwd test/ui dev",
-    "postinstall": "bun simple-git-hooks",
+    "prepare": "bun simple-git-hooks",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "release": "bumpp --commit --push --tag",

--- a/full-react-tailwindcss/package.json
+++ b/full-react-tailwindcss/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "bunup",
     "dev": "bun run --cwd test/ui dev",
-    "postinstall": "bun simple-git-hooks",
+    "prepare": "bun simple-git-hooks",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "release": "bumpp --commit --push --tag",

--- a/full-ts-monorepo/package.json
+++ b/full-ts-monorepo/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "bunup",
     "dev": "bunup --watch",
-    "postinstall": "bun simple-git-hooks",
+    "prepare": "bun simple-git-hooks",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "release": "bumpp -r --commit --push --tag",

--- a/full-ts/package.json
+++ b/full-ts/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "bunup",
     "dev": "bunup --watch",
-    "postinstall": "bun simple-git-hooks",
+    "prepare": "bun simple-git-hooks",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "release": "bumpp --commit --push --tag",


### PR DESCRIPTION
## Summary

Change `postinstall` to `prepare` on `package.json`

## Why

When a library created with Bunup is installed via `npm install` in an environment where Bun is not installed, an error occurs.

## How

The `post-install` script runs both on the end-user's side, so change it to `prepare` to ensure it only runs in the developer's environment.
